### PR TITLE
Fix validation of Belgian VAT numbers

### DIFF
--- a/lib/vat.ex
+++ b/lib/vat.ex
@@ -9,7 +9,7 @@ defmodule Vat do
   the EU with the EU's VIES on the web tool. VIES (VAT Information Exchange System)
   is a search engine (not a database) owned by the European Commission.
   The data is retrieved from national VAT databases when a search is made from
-  the VIES tool. 
+  the VIES tool.
   """
 
   @doc """
@@ -24,7 +24,7 @@ defmodule Vat do
 
   @spec valid_format?(binary, binary) :: boolean
   def valid_format?("AT", vat_number), do: Regex.match?(~r/^U\d{9}$/, vat_number)
-  def valid_format?("BE", vat_number), do: Regex.match?(~r/^0\d{10}$/, vat_number)
+  def valid_format?("BE", vat_number), do: Regex.match?(~r/^[01]\d{9}$/, vat_number)
   def valid_format?("CY", vat_number), do: Regex.match?(~r/^\d{8}[A-z]$/, vat_number)
   def valid_format?("DE", vat_number), do: Regex.match?(~r/^\d{9}$/, vat_number)
   def valid_format?("EE", vat_number), do: Regex.match?(~r/^\d{9}$/, vat_number)

--- a/test/vat_test.exs
+++ b/test/vat_test.exs
@@ -27,7 +27,8 @@ defmodule VatTest do
 
   describe "Belgium" do
     test "Valid Format VAT number provided" do
-      assert Vat.valid_format?("BE", "01234567890") == true
+      assert Vat.valid_format?("BE", "0123456789") == true
+      assert Vat.valid_format?("BE", "1123456789") == true
     end
 
     test "Invalid format VAT number, first charachter not 0" do
@@ -265,8 +266,8 @@ defmodule VatTest do
     test "Invalid Format VAT number, first 2 chars incorrect" do
       assert Vat.valid_format?("GB", "?!123") == false
       assert Vat.valid_format?("GB", "BR123") == false
-      assert Vat.valid_format?("GB", "gd123") == false 
-      assert Vat.valid_format?("GB", "ha123") == false 
+      assert Vat.valid_format?("GB", "gd123") == false
+      assert Vat.valid_format?("GB", "ha123") == false
     end
 
     test "Invalid format VAT number, too many digits" do
@@ -329,12 +330,12 @@ defmodule VatTest do
     end
 
     test "Invalid Format VAT number, special chars incorrect" do
-      assert Vat.valid_format?("IE", "12345678") == false 
-      assert Vat.valid_format?("IE", "1?345678") == false 
-      assert Vat.valid_format?("IE", "1B345678") == false 
+      assert Vat.valid_format?("IE", "12345678") == false
+      assert Vat.valid_format?("IE", "1?345678") == false
+      assert Vat.valid_format?("IE", "1B345678") == false
 
-      assert Vat.valid_format?("IE", "123456789") == false 
-      assert Vat.valid_format?("IE", "1234567BR") == false 
+      assert Vat.valid_format?("IE", "123456789") == false
+      assert Vat.valid_format?("IE", "1234567BR") == false
     end
 
     test "Invalid format VAT number, too many digits" do
@@ -386,7 +387,7 @@ defmodule VatTest do
       assert Vat.valid_format?("LT", "123K56789") == false
     end
   end
-  
+
   describe "Luxemburg" do
     test "Valid Format VAT number provided" do
       assert Vat.valid_format?("LU", "12345678") == true


### PR DESCRIPTION
Thanks for this library!

A client had an issue with the validation for their Belgian VAT number and we found this bug. I used this  document as reference: https://en.wikipedia.org/wiki/VAT_identification_number.